### PR TITLE
Add dttb - timestamps for Python exception tracebacks

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -694,6 +694,11 @@ projects:
     category: debugging
     pypi_id: manhole
     conda_id: conda-forge/manhole
+  - name: dttb
+    github_id: rocky-d/dttb
+    category: debugging
+    pypi_id: dttb
+    description: Add timestamps to Python exception tracebacks with a single line of code.
   - name: vprof
     github_id: nvdv/vprof
     category: profiling


### PR DESCRIPTION
## Add dttb to Debugging Tools

**[dttb](https://github.com/rocky-d/dttb)** adds timestamps to Python exception tracebacks with a single line of code.

```python
import dttb; dttb.apply()
```

After that one line, every traceback includes the exact timestamp when the exception occurred:

```
Traceback (most recent call last):
  ...at 2024-01-15 03:47:22.341 UTC
RuntimeError: something went wrong
```

**Features:**
- Patches both `sys.excepthook` and `threading.excepthook`
- Timezone configuration support
- Custom callbacks
- Zero dependencies

Invaluable for debugging long-running services, async apps, and multi-threaded programs where you need to know _when_ an error occurred, not just _that_ it occurred.

**Links:**
- GitHub: https://github.com/rocky-d/dttb
- PyPI: https://pypi.org/project/dttb/
- Docs: https://rocky-d.github.io/dttb/