### PR TITLE
Add project: agent-qa

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1384,3 +1384,8 @@ projects:
     github_id: xxh/xxh
     category: shell
     pypi_id: xxh-xxh
+  - name: agent-qa
+    github_id: vostride/agent-qa
+    category: testing
+    npm_id: agent-qa
+    license: FSL-1.1-ALv2


### PR DESCRIPTION
## Summary

- add `agent-qa` to the canonical `projects.yaml`
- classify it under Testing Tools
- record its published npm package and explicit SPDX license identifier
- leave the generated README unchanged

## Fit and scope

[Agent QA](https://github.com/vostride/agent-qa) is a black-box QA agent for natural-language web and mobile regression tests. It can exercise a deployed Python web application through its external interface without requiring the application to adopt a JavaScript testing library.

The tool itself is distributed through npm and requires Node.js 24 or newer. This is a language-independent companion for Python application teams, not a Python-native library or pytest integration. The catalog schema explicitly supports `npm_id`, and the entry records that package directly.

The current FSL-1.1-ALv2 license is source-available rather than OSI open source and converts to Apache-2.0 after two years. The explicit `license` property prevents the generator from inferring a permissive license. I am affiliated with Vostride and Agent QA.

## Validation

- Ruby's YAML parser loads all 270 project records successfully.
- The exact Agent QA record matches the expected name, GitHub ID, category, npm ID, and license.
- Project names and GitHub IDs remain unique.
- `npm view agent-qa` resolves version `0.1.21`, the `agent-qa` binary, and the Node.js `>=24` engine requirement.
- `https://spdx.org/licenses/FSL-1.1-ALv2.html` returns HTTP 200.
- `git diff --check` passes.
- Only `projects.yaml` changes, as required; the generated README remains untouched.
- README, `projects.yaml`, issues, and pull requests contain no existing Agent QA entry or proposal.

The full best-of regeneration was not run locally because this repository delegates it to the authenticated weekly `best-of-update-action` workflow.
