### PR TITLE
Add project: thailint

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -187,6 +187,10 @@ projects:
     category: linters
     pypi_id: pylint
     conda_id: conda-forge/pylint
+  - name: thailint
+    github_id: be-wise-be-kind/thai-lint
+    category: linters
+    pypi_id: thailint
   - name: ruff
     github_id: charliermarsh/ruff
     category: linters


### PR DESCRIPTION
Adds [thailint](https://github.com/be-wise-be-kind/thai-lint) to the `linters` category.

Disclosure: I maintain it.

A multi-language linter for anti-patterns that appear disproportionately in AI-generated code — duplicated blocks across files, excessive nesting, magic numbers, Single Responsibility violations, and linter suppressions added without justification. Python, TypeScript, JavaScript and Rust from one configuration, with a pre-commit hook per rule and text/JSON/SARIF output.

MIT. ~12.9k PyPI downloads/month, ~52k total. Active releases (0.24.0 today).

## Checks done before opening

- Searched `projects.yaml`, the README and the issue list — not already added or suggested.
- Added to `projects.yaml`, not the README.
- Title follows the `Add project: project-name` format from CONTRIBUTING.
- One project per PR.
- `projects.yaml` re-parsed after the edit: 270 projects, 42 in `linters`, entry reads back correctly.

`conda_id` is omitted as there is no conda package. Happy to add labels or move the category if you would prefer it elsewhere.