### PR TITLE
Add project: YYLO Ledger

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1384,3 +1384,7 @@ projects:
     github_id: xxh/xxh
     category: shell
     pypi_id: xxh-xxh
+  - name: YYLO Ledger
+    github_id: yylo-dev/yylo-ledger
+    category: others
+    pypi_id: yylo-ledger


### PR DESCRIPTION
## Summary

Adds [YYLO Ledger](https://github.com/yylo-dev/yylo-ledger) to `projects.yaml` (+4 lines, single file):

```yaml
  - name: YYLO Ledger
    github_id: yylo-dev/yylo-ledger
    category: others
    pypi_id: yylo-ledger
```

YYLO Ledger is a command-line, git-native task and workflow ledger for projects driven by coding agents: the Kanban board and task state are stored as hash-chained Markdown inside the repository, alongside receipts, archives, and typed merge/release flows across agent worktrees.

## Why it fits

- Python package distributed on PyPI (`pip install yylo-ledger`), MIT-licensed, with daily development activity (last push 2026-09-02).
- The toolchain it belongs to shows real usage: the companion CLI is at 57★ with ~560 npm downloads/month (`@yylo/cli`). The ledger itself is the newest component (created 2026-08-17), so I've kept the entry minimal and factual — if it is still too new for the list, closing this is completely fine and I'll happily re-submit once it has more traction.
- Categorized as `others` following the pre-commit precedent, since a task/workflow ledger does not match any of the classic Python-tooling categories; happy to re-file or drop the explicit category if you prefer.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('projects.yaml'))"` passes — 270 projects, names unique.
- Only `projects.yaml` is touched; the README is left to the weekly update.

## Disclosure

I'm on the YYLO team, and this PR was prepared with an AI coding agent and reviewed by me. A sibling entry for the same project is also open on `lukasmasuch/best-of-python` (#323) — both lists have distinct scopes, but I'm flagging it for transparency.
