### PR TITLE
Add project: extuno

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -487,6 +487,10 @@ projects:
     category: security
     pypi_id: safety
     conda_id: conda-forge/safety
+  - name: extuno
+    github_id: Extuno/extuno-cli
+    category: security
+    pypi_id: extuno
   - name: dodgy
     github_id: landscapeio/dodgy
     category: security


### PR DESCRIPTION
Adds `extuno` under `security` (Code Security).

**What it is.** A CLI that assesses a PyPI release before pip installs it. It resolves the exact version and digest from index metadata, checks it against a known-malicious catalog and against prior analysis, and submits an unseen release for static and sandbox analysis. pip is invoked only when the verdict allows it. The artifact is never downloaded, unpacked, imported or executed on the machine running the CLI, which is the point: a source distribution runs its `setup.py` during install, and a wheel runs at first import.

**Where it sits next to the existing entries.** `bandit` reads your own code, `safety` and `pip-audit` match installed versions against vulnerability records. This one asks what a package you are about to add actually does, and refuses the install when the answer is bad. Different half of the problem.

Pure Python, no runtime dependencies, MIT, CI across 3.9 to 3.13 on Linux, macOS and Windows. Also ships a GitHub action and pre-commit hooks.

**Disclosure.** I am the author. The CLI is open source; catalog lookups and previously analysed releases resolve free, and first-time analysis of an unseen release is metered against a commercial backend. Noting it plainly since the list carries `safety`, which has the same shape.

The project is new, so I expect it to sit in the hidden block until it clears `min_stars`. Adding it now so it surfaces on its own when it does.
